### PR TITLE
replaceMethod is deprecated

### DIFF
--- a/slides/api/Snippets.gs
+++ b/slides/api/Snippets.gs
@@ -250,7 +250,7 @@ Snippets.prototype.imageMerging = function(templatePresentationId, imageUrl, cus
   var requests = [{
     replaceAllShapesWithImage: {
       imageUrl: logoUrl,
-      replaceMethod: 'CENTER_INSIDE',
+      imageReplaceMethod: 'CENTER_INSIDE',
       containsText: {
         text: '{{company-logo}}',
         matchCase: true
@@ -259,7 +259,7 @@ Snippets.prototype.imageMerging = function(templatePresentationId, imageUrl, cus
   }, {
     replaceAllShapesWithImage: {
       imageUrl: customerGraphicUrl,
-      replaceMethod: 'CENTER_INSIDE',
+      imageReplaceMethod: 'CENTER_INSIDE',
       containsText: {
         text: '{{customer-graphic}}',
         matchCase: true


### PR DESCRIPTION
The `replaceMethod` is [deprecated](https://developers.google.com/slides/reference/rest/v1/presentations/request#replaceallshapeswithimagerequest), use `imageReplaceMethod` instead.

If you specify both a `replaceMethod` and an `imageReplaceMethod`, the `imageReplaceMethod` takes precedence.
