### PR TITLE
Resolve getActivePresentation Authorization issue in Slides Progress Bar example

### DIFF
--- a/slides/progress/progress.gs
+++ b/slides/progress/progress.gs
@@ -19,7 +19,6 @@
  */
 var BAR_ID = 'PROGRESS_BAR_ID';
 var BAR_HEIGHT = 10; // px
-var presentation = SlidesApp.getActivePresentation();
 
 /**
  * Runs when the add-on is installed.
@@ -49,6 +48,7 @@ function onOpen(e) {
  */
 function createBars() {
   deleteBars(); // Delete any existing progress bars
+  var presentation = SlidesApp.getActivePresentation();
   var slides = presentation.getSlides();
   for (var i = 0; i < slides.length; ++i) {
     var ratioComplete = (i / (slides.length - 1));
@@ -68,6 +68,7 @@ function createBars() {
  * Deletes all progress bar rectangles.
  */
 function deleteBars() {
+  var presentation = SlidesApp.getActivePresentation();
   var slides = presentation.getSlides();
   for (var i = 0; i < slides.length; ++i) {
     var elements = slides[i].getPageElements();


### PR DESCRIPTION
This resolves an issue I was seeing when walking through the quickstart guide here: https://developers.google.com/gsuite/add-ons/editors/slides/quickstart/progress-bar  

Essentially I am seeing the following in StackDriver Logs for a "Simple Trigger" when I refresh my Google Presentation browser window as directed to do in the guide:

```
Exception: Authorization is required to perform that action.
    at [unknown function](progress:6:30)
```

This change is to avoid running `getActivePresentation` in the global scope. Note that there are some references to fixing this by running any function in the Apps Script editor see https://developers.google.com/apps-script/guides/support/troubleshooting#execution_transcript, which appears to have resolve others experiencing this issue, but there are also some suggesting that this no longer works, see https://webapps.stackexchange.com/a/136707 and the comment from kurokirasama.

I'm unsure as to what has changed to require this, but this at least resolves my immediate issue.

Resolves #175