### PR TITLE
fix: 'No HTML file named javaScript was found'

### DIFF
--- a/tasks/simpleTasks/page.html
+++ b/tasks/simpleTasks/page.html
@@ -30,7 +30,7 @@
   </ul>
 </fieldset>
 
-<?!= HtmlService.createHtmlOutputFromFile('javaScript').getContent(); ?>
+<?!= HtmlService.createHtmlOutputFromFile('javascript').getContent(); ?>
 
 </body>
 </html>


### PR DESCRIPTION
`No HTML file named javaScript was found. (line 22, file "simpleTasks")` error due to capitalization typo in requested filename.