### PR TITLE
Fix incorrect Google Developers channelId

### DIFF
--- a/advanced/youtube.gs
+++ b/advanced/youtube.gs
@@ -99,7 +99,7 @@ function retrieveMyUploads() {
  */
 function addSubscription() {
   // Replace this channel ID with the channel ID you want to subscribe to
-  const channelId = 'UC9gFih9rw0zNCK3ZtoKQQyA';
+  const channelId = 'UC_x5XG1OV2P6uZZ5FSM9Ttw';
   const resource = {
     snippet: {
       resourceId: {


### PR DESCRIPTION
# Description

The snippet in https://developers.google.com/apps-script/advanced/youtube contains this sample code, as a way to subscribe to the Goggle Developers Youtube channel.

When run, the account is subscribed to an unexpected channel:
- Current, wrong: https://www.youtube.com/channel/UC9gFih9rw0zNCK3ZtoKQQyA (JennaMarbles)
- Expected, correct: https://www.youtube.com/channel/UC_x5XG1OV2P6uZZ5FSM9Ttw (Google Developers)

This error exists since at least 5 years ago when 9kopb notified it, but was ignored: https://github.com/googleworkspace/apps-script-samples/commit/499e6508653f6a620e34542f138d5b1a5aac69f2#r45916392

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have performed a peer-reviewed with team member(s)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
