### PR TITLE
Update spreadsheet_snippets.gs

### DIFF
--- a/sheets/api/spreadsheet_snippets.gs
+++ b/sheets/api/spreadsheet_snippets.gs
@@ -240,7 +240,6 @@ Snippets.prototype.batchUpdateValues =
  */
 Snippets.prototype.appendValues = (spreadsheetId, range,
   valueInputOption, _values) => {
-  // [START sheets_append_values]
   let values = [
     [
       // Cell values ...

--- a/sheets/api/spreadsheet_snippets.gs
+++ b/sheets/api/spreadsheet_snippets.gs
@@ -147,10 +147,10 @@ Snippets.prototype.batchGetValues = (spreadsheetId,
  * Updates the values in the specified range
  * @param {string} spreadsheetId spreadsheet's ID
  * @param {string} range the range of cells in spreadsheet
- * @param {} valueInputOption determines how the input should be interpreted
+ * @param {string} valueInputOption determines how the input should be interpreted
  * @see
  * https://developers.google.com/sheets/api/reference/rest/v4/ValueInputOption
- * @param {list<string>} _values list of values to input
+ * @param {list<list<string>>} _values list of string lists to input
  * @returns {*} spreadsheet with updated values
  */
 Snippets.prototype.updateValues = (spreadsheetId, range,
@@ -186,10 +186,10 @@ Snippets.prototype.updateValues = (spreadsheetId, range,
  * Updates the values in the specified range
  * @param {string} spreadsheetId spreadsheet's ID
  * @param {string} range range of cells of the spreadsheet
- * @param valueInputOption determines how the input should be interpreted
+ * @param {string} valueInputOption determines how the input should be interpreted
  * @see
  * https://developers.google.com/sheets/api/reference/rest/v4/ValueInputOption
- * @param {list<string>} _values list of values to input
+ * @param {list<list<string>>} _values list of string values to input
  * @returns {*} spreadsheet with updated values
  */
 Snippets.prototype.batchUpdateValues =


### PR DESCRIPTION

# Description
_values has to be [[x],[y],[z],...] not [x,y,z...]  and valueInputOption is inputted as a string not an enum

Fixes # (issue)

## Is it been tested?
- [ ] Development testing done

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have performed a peer-reviewed with team member(s)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
