### PR TITLE
Add (err) to catch so it can be printed in log.

### DIFF
--- a/service/jdbc.gs
+++ b/service/jdbc.gs
@@ -120,7 +120,7 @@ function writeManyRecords() {
 
     const end = new Date();
     Logger.log('Time elapsed: %sms for %s rows.', end - start, batch.length);
-  } catch {
+  } catch (err) {
     // TODO(developer) - Handle exception from the API
     Logger.log('Failed with an error %s', err.message);
   }
@@ -153,7 +153,7 @@ function readFromTable() {
 
     const end = new Date();
     Logger.log('Time elapsed: %sms', end - start);
-  } catch {
+  } catch (err) {
     // TODO(developer) - Handle exception from the API
     Logger.log('Failed with an error %s', err.message);
   }


### PR DESCRIPTION
# Description

Update example code which attempts to log `err` to actually make `err` an available variable with `catch (err) {`.