### PR TITLE
feat(calendar): Fixed broken link and added support for indirect members or multiple groups to Team Calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ align="left"
 width="96px"/>
 ### Calendar
 - [List upcoming events](calendar/quickstart)
-- [Create a vacation calendar](calendar/vacationCalendar)
+- [Create a vacation calendar](solutions/automations/vacation-calendar/Code.js)
 
 <img
 src="https://www.gstatic.com/images/branding/product/2x/classroom_96dp.png"


### PR DESCRIPTION
# Description

1. Fixed a **broken** link in the README to the vacation calendar script. Without this fix, users may not find this script.
1. Added a feature to the vacation to also support indirect members or multiple groups. Without it the calendar is limited since many groups also contain indirect members and there was no alternative to manually specify multiple groups.

## Is it been tested?
- [X] Production testing done

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have performed a peer-reviewed with team member(s)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
