### PR TITLE
fix: Removes reference to free storage quota for 1P Drive files.

### DIFF
--- a/advanced/drive.gs
+++ b/advanced/drive.gs
@@ -96,8 +96,7 @@ function addCustomProperty(fileId) {
 /**
  * Lists the revisions of a given file. Note that some properties of revisions
  * are only available for certain file types. For example, Google Workspace
- * application files do not consume space in Google Drive and thus list a file
- * size of 0.
+ * application files contain links to export the file to different formats.
  * @param {string} fileId The ID of the file to list revisions for.
  */
 function listRevisions(fileId) {


### PR DESCRIPTION
All files created/edited after June 1, 2021 consume storage quota in Drive.

https://support.google.com/googleone/answer/9312312?hl=en

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Is it been tested?
- [ ] Development testing done

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have performed a peer-reviewed with team member(s)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
