### PR TITLE
Fix paging examples to continue on empty page

### DIFF
--- a/advanced/drive.gs
+++ b/advanced/drive.gs
@@ -52,20 +52,20 @@ function listRootFolders() {
         pageSize: 100,
         pageToken: pageToken
       });
+      pageToken = folders.nextPageToken;
       if (!folders.files || folders.files.length === 0) {
-        console.log('All folders found.');
-        return;
+        continue;
       }
       for (let i = 0; i < folders.files.length; i++) {
         const folder = folders.files[i];
         console.log('%s (ID: %s)', folder.name, folder.id);
       }
-      pageToken = folders.nextPageToken;
     } catch (err) {
       // TODO (developer) - Handle exception
       console.log('Failed with error %s', err.message);
     }
   } while (pageToken);
+  console.log('All folders found.');
 }
 // [END drive_list_root_folders]
 
@@ -109,9 +109,9 @@ function listRevisions(fileId) {
       revisions = Drive.Revisions.list(
           fileId,
           {'fields': 'revisions(modifiedTime,size),nextPageToken'});
+      pageToken = revisions.nextPageToken;
       if (!revisions.revisions || revisions.revisions.length === 0) {
-        console.log('All revisions found.');
-        return;
+        continue;
       }
       for (let i = 0; i < revisions.revisions.length; i++) {
         const revision = revisions.revisions[i];
@@ -119,12 +119,12 @@ function listRevisions(fileId) {
         console.log('Date: %s, File size (bytes): %s', date.toLocaleString(),
             revision.size);
       }
-      pageToken = revisions.nextPageToken;
     } catch (err) {
       // TODO (developer) - Handle exception
       console.log('Failed with error %s', err.message);
     }
   } while (pageToken);
+  console.log('All revisions found.');
 }
 
 // [END drive_list_revisions]


### PR DESCRIPTION
# Description

Fix the paging examples to handle empty pages. The loop should only stop if nextPageToken is not provided in the
response.

Fixes # (issue)

## Is it been tested?
- [ ] Development testing done

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have performed a peer-reviewed with team member(s)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
