### PR TITLE
fix: write OOO event type using advanced Calendar service

### DIFF
--- a/solutions/automations/folder-creation/Code.js
+++ b/solutions/automations/folder-creation/Code.js
@@ -1,0 +1,33 @@
+// To learn how to use this script, refer to the video: https://youtu.be/Utl57R7I2Cs
+
+/*
+Copyright 2022 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+/* 
+This function will create a new folder in the defined Shard Drive.
+You define the Shared Drive by adding its ID on line number 26.
+The parameter 'project' is passed in from the AppSheet app. 
+Please watch this video tutorial to see how to use this script: https://youtu.be/Utl57R7I2Cs
+*/
+
+function createNewFolder(project) {
+    const newFolderId = Drive.Files.insert({
+      parents: [{id: [ADD YOUR SHARED DRIVE FOLDER ID HERE]}],
+      title: project,
+      mimeType: 'application/vnd.google-apps.folder'
+    }, null, {supportsAllDrives: true}).id;
+  
+    return `https://drive.google.com/drive/folders/${newFolderId}?usp=share_link`;
+  }
+  

--- a/solutions/automations/folder-creation/README.md
+++ b/solutions/automations/folder-creation/README.md
@@ -1,0 +1,11 @@
+# Folder creation
+
+This code sample is part of a video tutorial on how to combine AppSheet and Apps Script.
+
+You can watch the video tutorial to find out how to use the sample.
+
+<p align="center">
+<iframe width="560" height="315" src="https://www.youtube.com/embed/Utl57R7I2Cs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</p>
+
+See the [Google Apps Script Documentation] (https://developers.google.com/apps-script/advanced/drive) for additional information about the advanced Google Drive services.

--- a/solutions/automations/folder-creation/appscript.json
+++ b/solutions/automations/folder-creation/appscript.json
@@ -1,0 +1,14 @@
+{
+    "timeZone": "Europe/Madrid",
+    "dependencies": {
+      "enabledAdvancedServices": [
+        {
+          "userSymbol": "Drive",
+          "version": "v2",
+          "serviceId": "drive"
+        }
+      ]
+    },
+    "exceptionLogging": "STACKDRIVER",
+    "runtimeVersion": "V8"
+  }

--- a/solutions/ooo-chat-app/Code.js
+++ b/solutions/ooo-chat-app/Code.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2022 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 /**
  * Responds to an ADDED_TO_SPACE event in Chat.
  * @param {object} event the event object from Chat

--- a/solutions/ooo-chat-app/Code.js
+++ b/solutions/ooo-chat-app/Code.js
@@ -4,207 +4,232 @@
  * @return {object} JSON-formatted response
  * @see https://developers.google.com/hangouts/chat/reference/message-formats/events
  */
- function onAddToSpace(event) {
-    let message = 'Thank you for adding me to ';
-    if (event.space.type === 'DM') {
-      message += 'a DM, ' + event.user.displayName + '!';
-    } else {
-      message += event.space.displayName;
+function onAddToSpace(event) {
+  let message = 'Thank you for adding me to ';
+  if (event.space.type === 'DM') {
+    message += 'a DM, ' + event.user.displayName + '!';
+  } else {
+    message += event.space.displayName;
+  }
+  return { text: message };
+}
+
+/**
+ * Responds to a REMOVED_FROM_SPACE event in Chat.
+ * @param {object} event the event object from Chat
+ * @param {object} event the event object from Chat
+ * @see https://developers.google.com/hangouts/chat/reference/message-formats/events
+ */
+function onRemoveFromSpace(event) {
+  console.log('App removed from ', event.space.name);
+}
+
+
+/**
+ * Responds to a MESSAGE event triggered in Chat.
+ * @param {object} event the event object from Chat
+ * @return {function} call the respective function
+ */
+function onMessage(event) {
+  const message = event.message;
+
+  if (message.slashCommand) {
+    switch (message.slashCommand.commandId) {
+      case 1: // Help command
+        return createHelpCard();
+      case 2: // Block out day command
+        return blockDayOut();
+      case 3: // Cancel all meetings command
+        return cancelAllMeetings();
+      case 4: // Set auto reply command
+        return setAutoReply();
     }
-    return { text: message };
   }
-  
-  /**
-   * Responds to a REMOVED_FROM_SPACE event in Chat.
-   * @param {object} event the event object from Chat
-   * @param {object} event the event object from Chat
-   * @see https://developers.google.com/hangouts/chat/reference/message-formats/events
-   */
-  function onRemoveFromSpace(event) {
-    console.log('App removed from ', event.space.name);
-  }
-  
-  
-  /**
-   * Responds to a MESSAGE event triggered in Chat.
-   * @param {object} event the event object from Chat
-   * @return {function} call the respective function
-   */
-  function onMessage(event) {
-    const message = event.message;
-  
-    if (message.slashCommand) {
-      switch (message.slashCommand.commandId) {
-        case 1: // Help command
-          return createHelpCard();
-        case 2: // Block out day command
-          return blockDayOut();
-        case 3: // Cancel all meetings command
-          return cancelAllMeetings();
-        case 4: // Set auto reply command
-          return setAutoReply();
-      }
-    }
-  }
-  
-  function createHelpCard() {
-    return {
-      "cardsV2": [
-        {
-          "cardId": "2",
-          "card": {
-            "sections": [
-              {
-                "header": "",
-                "widgets": [
-                  {
-                    "decoratedText": {
-                      "topLabel": "",
-                      "text": "Hi! 👋 I'm here to help you with your out of office tasks.<br><br>Here's a list of commands I understand.",
-                      "wrapText": true
-                    }
+}
+
+function createHelpCard() {
+  return {
+    "cardsV2": [
+      {
+        "cardId": "2",
+        "card": {
+          "sections": [
+            {
+              "header": "",
+              "widgets": [
+                {
+                  "decoratedText": {
+                    "topLabel": "",
+                    "text": "Hi! 👋 I'm here to help you with your out of office tasks.<br><br>Here's a list of commands I understand.",
+                    "wrapText": true
                   }
-                ]
-              },
-              {
-                "widgets": [
-                  {
-                    "decoratedText": {
-                      "topLabel": "",
-                      "text": "<b>/blockDayOut</b>: I will block out your calendar for you.",
-                      "wrapText": true
-                    }
-                  },
-                  {
-                    "decoratedText": {
-                      "topLabel": "",
-                      "text": "<b>/cancelAllMeetings</b>: I will cancel all your meetings for the day.",
-                      "wrapText": true
-                    }
-                  },
-                  {
-                    "decoratedText": {
-                      "topLabel": "",
-                      "text": "<b>/setAutoReply</b>: Set an out of office auto reply in Gmail.",
-                      "wrapText": true
-                    }
+                }
+              ]
+            },
+            {
+              "widgets": [
+                {
+                  "decoratedText": {
+                    "topLabel": "",
+                    "text": "<b>/blockDayOut</b>: I will block out your calendar for you.",
+                    "wrapText": true
                   }
-                ]
-              }
-            ],
-            "header": {
-              "title": "OOO app",
-              "subtitle": "Helping you manage your OOO",
-              "imageUrl": "https://goo.gle/3SfMkjb",
-              "imageType": "SQUARE"
+                },
+                {
+                  "decoratedText": {
+                    "topLabel": "",
+                    "text": "<b>/cancelAllMeetings</b>: I will cancel all your meetings for the day.",
+                    "wrapText": true
+                  }
+                },
+                {
+                  "decoratedText": {
+                    "topLabel": "",
+                    "text": "<b>/setAutoReply</b>: Set an out of office auto reply in Gmail.",
+                    "wrapText": true
+                  }
+                }
+              ]
             }
+          ],
+          "header": {
+            "title": "OOO app",
+            "subtitle": "Helping you manage your OOO",
+            "imageUrl": "https://goo.gle/3SfMkjb",
+            "imageType": "SQUARE"
           }
         }
-      ]
+      }
+    ]
+  }
+}
+
+/**
+ * Adds an all day event to the users Google Calendar.
+ * @return {object} JSON-formatted response
+ */
+function blockDayOut() {
+  blockOutCalendar();
+  return createResponseCard('Your calendar has been blocked out for you.')
+}
+
+/**
+ * Cancels all of the users meeting for the current day.
+ * @return {object} JSON-formatted response
+ */
+function cancelAllMeetings() {
+  cancelMeetings();
+  return createResponseCard('All your meetings have been canceled.')
+}
+
+/**
+ * Sets an out of office auto reply in the users Gmail account.
+ * @return {object} JSON-formatted response
+ */
+function setAutoReply() {
+  turnOnAutoResponder();
+  return createResponseCard('The out of office auto reply has been turned on.')
+}
+
+
+const ONE_DAY_MILLIS = 24 * 60 * 60 * 1000;
+
+/**
+ * Creates an out of office event in the user's Calendar.
+ */
+function blockOutCalendar() {
+
+/**
+ * Helper function to get a the current date and set the time for the start and end of the event.
+ * @param {number} hour The hour of the day for the new date.
+ * @param {number} minutes The minutes of the day for the new date.
+ * @return {Date} The new date.
+ */
+  function getDateAndHours(hour, minutes) {
+    const date = new Date();
+    date.setHours(hour);
+    date.setMinutes(minutes);
+    date.setSeconds(0);
+    date.setMilliseconds(0);
+    return date.toISOString();
+  } 
+  
+  const event = {
+    start: {dateTime: getDateAndHours(9,00)},
+    end: {dateTime: getDateAndHours(17,00)},
+    eventType: 'outOfOffice',
+    summary: 'Out of office',
+    outOfOfficeProperties: {
+      autoDeclineMode: 'declineOnlyNewConflictingInvitations',
+      declineMessage: 'Declined because I am taking a day of.',
     }
   }
-  
-  /**
-   * Adds an all day event to the users Google Calendar.
-   * @return {object} JSON-formatted response
-   */
-  function blockDayOut() {
-    blockOutCalendar();
-    return createResponseCard('Your calendar has been blocked out for you.')
-  }
-  
-  /**
-   * Cancels all of the users meeting for the current day.
-   * @return {object} JSON-formatted response
-   */
-  function cancelAllMeetings() {
-    cancelMeetings();
-    return createResponseCard('All your meetings have been canceled.')
-  }
-  
-  /**
-   * Sets an out of office auto reply in the users Gmail account.
-   * @return {object} JSON-formatted response
-   */
-  function setAutoReply() {
-    turnOnAutoResponder();
-    return createResponseCard('The out of office auto reply has been turned on.')
-  }
-  
-  
-  const ONE_DAY_MILLIS = 24 * 60 * 60 * 1000;
-  
-  /**
-   * Places an all-day meeting on the user's Calendar.
-   */
-  function blockOutCalendar() {
-    CalendarApp.createAllDayEvent('I am out of office today', new Date(), new Date(Date.now() + ONE_DAY_MILLIS));
-  }
-  
-  /**
-   * Declines all meetings for the day.
-   */
-  
-  function cancelMeetings() {
-    const events = CalendarApp.getEventsForDay(new Date());
-  
-    events.forEach(function(event) {
-      if (event.getGuestList().length > 0) {
-        event.setMyStatus(CalendarApp.GuestStatus.NO);
-      }
-    });
-  }
-  
-  /**
-   * Turns on the user's vacation response for today in Gmail.
-   */
-  function turnOnAutoResponder() {
-    const currentTime = (new Date()).getTime();
-    Gmail.Users.Settings.updateVacation({
-      enableAutoReply: true,
-      responseSubject: 'I am out of the office today',
-      responseBodyHtml: 'I am out of the office today; will be back on the next business day.<br><br><i>Created by OOO Chat app!</i>',
-      restrictToContacts: true,
-      restrictToDomain: true,
-      startTime: currentTime,
-      endTime: currentTime + ONE_DAY_MILLIS
-    }, 'me');
-  }
-  
-  function createResponseCard(responseText) {
-    return {
-      "cardsV2": [
-        {
-          "cardId": "1",
-          "card": {
-            "sections": [
-              {
-                "widgets": [
-                  {
-                    "decoratedText": {
-                      "topLabel": "",
-                      "text": responseText,
-                      "startIcon": {
-                        "knownIcon": "NONE",
-                        "altText": "Task done",
-                        "iconUrl": "https://fonts.gstatic.com/s/i/short-term/web/system/1x/task_alt_gm_grey_48dp.png"
-                      },
-                      "wrapText": true
-                    }
+  Calendar.Events.insert(event, 'primary');
+}
+
+/**
+ * Declines all meetings for the day.
+ */
+
+function cancelMeetings() {
+  const events = CalendarApp.getEventsForDay(new Date());
+
+  events.forEach(function(event) {
+    if (event.getGuestList().length > 0) {
+      event.setMyStatus(CalendarApp.GuestStatus.NO);
+    }
+  });
+}
+
+/**
+ * Turns on the user's vacation response for today in Gmail.
+ */
+function turnOnAutoResponder() {
+  const currentTime = (new Date()).getTime();
+  Gmail.Users.Settings.updateVacation({
+    enableAutoReply: true,
+    responseSubject: 'I am out of the office today',
+    responseBodyHtml: 'I am out of the office today; will be back on the next business day.<br><br><i>Created by OOO Chat app!</i>',
+    restrictToContacts: true,
+    restrictToDomain: true,
+    startTime: currentTime,
+    endTime: currentTime + ONE_DAY_MILLIS
+  }, 'me');
+}
+
+function createResponseCard(responseText) {
+  return {
+    "cardsV2": [
+      {
+        "cardId": "1",
+        "card": {
+          "sections": [
+            {
+              "widgets": [
+                {
+                  "decoratedText": {
+                    "topLabel": "",
+                    "text": responseText,
+                    "startIcon": {
+                      "knownIcon": "NONE",
+                      "altText": "Task done",
+                      "iconUrl": "https://fonts.gstatic.com/s/i/short-term/web/system/1x/task_alt_gm_grey_48dp.png"
+                    },
+                    "wrapText": true
                   }
-                ]
-              }
-            ],
-            "header": {
-              "title": "OOO app",
-              "subtitle": "Helping you manage your OOO",
-              "imageUrl": "https://goo.gle/3SfMkjb",
-              "imageType": "CIRCLE"
+                }
+              ]
             }
+          ],
+          "header": {
+            "title": "OOO app",
+            "subtitle": "Helping you manage your OOO",
+            "imageUrl": "https://goo.gle/3SfMkjb",
+            "imageType": "CIRCLE"
           }
         }
-      ]
-    }
+      }
+    ]
   }
-  
-  
+}
+

--- a/solutions/ooo-chat-app/Code.js
+++ b/solutions/ooo-chat-app/Code.js
@@ -132,19 +132,17 @@ function setAutoReply() {
 }
 
 
-const ONE_DAY_MILLIS = 24 * 60 * 60 * 1000;
 
 /**
  * Creates an out of office event in the user's Calendar.
  */
 function blockOutCalendar() {
-
-/**
- * Helper function to get a the current date and set the time for the start and end of the event.
- * @param {number} hour The hour of the day for the new date.
- * @param {number} minutes The minutes of the day for the new date.
- * @return {Date} The new date.
- */
+  /**
+   * Helper function to get a the current date and set the time for the start and end of the event.
+   * @param {number} hour The hour of the day for the new date.
+   * @param {number} minutes The minutes of the day for the new date.
+   * @return {Date} The new date.
+   */
   function getDateAndHours(hour, minutes) {
     const date = new Date();
     date.setHours(hour);
@@ -170,7 +168,6 @@ function blockOutCalendar() {
 /**
  * Declines all meetings for the day.
  */
-
 function cancelMeetings() {
   const events = CalendarApp.getEventsForDay(new Date());
 
@@ -185,6 +182,7 @@ function cancelMeetings() {
  * Turns on the user's vacation response for today in Gmail.
  */
 function turnOnAutoResponder() {
+  const ONE_DAY_MILLIS = 24 * 60 * 60 * 1000;
   const currentTime = (new Date()).getTime();
   Gmail.Users.Settings.updateVacation({
     enableAutoReply: true,

--- a/solutions/ooo-chat-app/README.md
+++ b/solutions/ooo-chat-app/README.md
@@ -1,3 +1,5 @@
+# OOO Chat App
+
 Sample code for a custom Google Chat app that manages your out of office tasks.
 
 Learn more about Chat apps: https://developers.google.com/chat

--- a/solutions/ooo-chat-app/README.md
+++ b/solutions/ooo-chat-app/README.md
@@ -2,4 +2,4 @@
 
 Sample code for a custom Google Chat app that manages your out of office tasks.
 
-Learn more about Chat apps: https://developers.google.com/chat
+Learn more about [Chat apps](https://developers.google.com/chat).

--- a/solutions/ooo-chat-app/appsscript.json
+++ b/solutions/ooo-chat-app/appsscript.json
@@ -1,15 +1,20 @@
 {
-    "timeZone": "Europe/Madrid",
-    "exceptionLogging": "STACKDRIVER",
-    "runtimeVersion": "V8",
-    "dependencies": {
-      "enabledAdvancedServices": [
-        {
-          "userSymbol": "Gmail",
-          "version": "v1",
-          "serviceId": "gmail"
-        }
-      ]
-    },
-    "chat": {}
-  }
+  "timeZone": "Europe/Madrid",
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
+  "dependencies": {
+    "enabledAdvancedServices": [
+      {
+        "userSymbol": "Gmail",
+        "version": "v1",
+        "serviceId": "gmail"
+      },
+      {
+        "userSymbol": "Calendar",
+        "version": "v3",
+        "serviceId": "calendar"
+      }
+    ]
+  },
+  "chat": {}
+}


### PR DESCRIPTION
# Description

The Calendar API now has the option of writing event type out of office through the advance Calendar service for Apps Script. I've updated the script to use this new feature instead of the workaround of creating a default event.

Fixes # (issue)

## Is it been tested?
- [x] Development testing done

## Checklist

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have performed a peer-reviewed with team member(s)
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
