### PR TITLE
fix: Allowlist URLs through manifest for Preview links with Smart Chips

### DIFF
--- a/solutions/add-on/book-smartchip/README.md
+++ b/solutions/add-on/book-smartchip/README.md
@@ -1,0 +1,5 @@
+# Preview links from Google Books with smart chips
+
+See 
+https://developers.google.com/workspace/add-ons/samples/preview-links-google-books
+for additional details.

--- a/solutions/add-on/book-smartchip/appsscript.json
+++ b/solutions/add-on/book-smartchip/appsscript.json
@@ -6,6 +6,9 @@
     "https://www.googleapis.com/auth/workspace.linkpreview",
     "https://www.googleapis.com/auth/script.external_request"
   ],
+  "urlFetchWhitelist": [
+    "https://www.googleapis.com/books/v1/volumes/"
+  ],
   "addOns": {
     "common": {
       "name": "Preview Books Add-on",


### PR DESCRIPTION
# Description

Fix https://developers.google.com/apps-script/add-ons/concepts/workspace-manifests#allowlist