### PR TITLE
Update Snippets.gs

### DIFF
--- a/slides/api/Snippets.gs
+++ b/slides/api/Snippets.gs
@@ -90,13 +90,13 @@ function createSlide(presentationId, pageId) {
       requests: requests
     }, presentationId);
     console.log('Created slide with ID: %s', createSlideResponse.replies[0].createSlide.objectId);
-    // [END slides_create_slide]
     return createSlideResponse;
   } catch (err) {
     // TODO (Developer) - Handle exception
     console.log('Failed with error: %s', err.error);
   }
 };
+// [END slides_create_slide]
 
 // [START slides_create_textbox_with_text]
 /**


### PR DESCRIPTION
# Description

Move the end slide tag from within the `try` to the end of the function. It's cutting off the rest of the code from the example in the docs: https://developers.google.com/slides/api/guides/create-slide#example

Fixes # (issue)

## Is it been tested?
- [ ] Development testing done

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have performed a peer-reviewed with team member(s)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
