### PR TITLE
Update spreadsheet_snippets.gs to include Sheets.newAppendCellsRequest() & update the range param definition

### DIFF
--- a/sheets/api/spreadsheet_snippets.gs
+++ b/sheets/api/spreadsheet_snippets.gs
@@ -231,11 +231,11 @@ Snippets.prototype.batchUpdateValues =
 /**
  * Appends values to the specified range
  * @param {string} spreadsheetId spreadsheet's ID
- * @param {string} range range of cells in the spreadsheet
+ * @param {string} range The A1 notation of a range to search for a logical table of data.
  * @param valueInputOption determines how the input should be interpreted
  * @see
  * https://developers.google.com/sheets/api/reference/rest/v4/ValueInputOption
- * @param {list<string>} _values list of rows of values to input
+ * @param {*[][]} _values list of rows of values to input
  * @returns {*} spreadsheet with appended values
  */
 Snippets.prototype.appendValues = (spreadsheetId, range,
@@ -255,10 +255,14 @@ Snippets.prototype.appendValues = (spreadsheetId, range,
 
     let appendRequest = Sheets.newAppendCellsRequest();
     appendRequest.sheetId = spreadsheetId;
-    appendRequest.rows = [valueRange];
+    appendRequest.rows = valueRange;
 
-    const result = Sheets.Spreadsheets.Values.append(valueRange, spreadsheetId,
-      range, {valueInputOption: valueInputOption});
+    const result = Sheets.Spreadsheets.Values.append(
+      appendRequest.rows, 
+      appendRequest.sheetId, 
+      range, 
+      { valueInputOption: valueInputOption }
+    );
     return result;
   } catch (err) {
     // TODO (developer) - Handle exception


### PR DESCRIPTION
Uses Sheets.newAppendCellsRequest() in request for the rows and sheet id. Updates the `range` parameter description to to the one found in the documentation.  Updates the `_values` param to correct JSdoc format.

# Description

1. Includes the `Sheets.newAppendCellsRequest()` properties into the request. Previously they were not used in the script.
2. Updates the `range` param definition to more clearly explain what the range is doing. Here, I copied the definition from the documentation. [See](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/append?apix_params=%7B%22spreadsheetId%22%3A%221sReaoJmec6AOuW6YE58u3N_i8qJmqV0aoHbCmrHL448%22%2C%22range%22%3A%22Sheet4!A2%3AA%22%2C%22valueInputOption%22%3A%22USER_ENTERED%22%2C%22resource%22%3A%7B%22values%22%3A%5B%5B1%2C2%2C3%2C4%2C5%5D%2C%5B6%2C7%2C8%2C9%2C10%5D%5D%7D%7D#path-parameters)
3. Changes the `list<string>` param value to correct  JSdoc format. 

Fixes # (522)

## Is it been tested?
- [x] Development testing done

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have performed a peer-reviewed with team member(s)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
