### PR TITLE
Add examples for resultSet.getRow and preparedStatement.executeBatch

### DIFF
--- a/service/test_jdbc.gs
+++ b/service/test_jdbc.gs
@@ -56,11 +56,28 @@ function itShouldWriteManyRecords() {
 }
 
 /**
+ * Tests writeManyRecordsUsingExecuteBatch function of jdbc.gs
+ */
+function itShouldWriteManyRecordsUsingExecuteBatch() {
+  console.log('itShouldWriteManyRecordsUsingExecuteBatch');
+  writeManyRecordsUsingExecuteBatch();
+}
+
+
+/**
  * Tests readFromTable function of jdbc.gs
  */
 function itShouldReadFromTable() {
   console.log('itShouldReadFromTable');
   readFromTable();
+}
+
+/**
+ * Tests readFromTableUsingGetRows function of jdbc.gs
+ */
+function itShouldReadFromTableUsingGetRows() {
+  console.log('itShouldReadFromTableUsingGetRows');
+  readFromTableUsingGetRows();
 }
 
 /**
@@ -73,4 +90,6 @@ function RUN_ALL_TESTS() {
   itShouldWriteOneRecord();
   itShouldWriteManyRecords();
   itShouldReadFromTable();
+  itShouldReadFromTableUsingGetRows();
+  itShouldWriteManyRecordsUsingExecuteBatch();
 }


### PR DESCRIPTION
Add examples for resultSet.getRow() and preparedStatement.executeBatch() for faster JDBC operations.

# Description

This provides an alternative for faster reads and writes in JDBC calls when using apps script in V8 runtime

Fixes # (issue)

## Is it been tested?
- [Y ] Development testing done

## Checklist

- [Y] My code follows the style guidelines of this project
- [Y] I have performed a self-review of my own code
- [Y] I have performed a peer-reviewed with team member(s)
- [Y] I have commented my code, particularly in hard-to-understand areas
- [Y] I have made corresponding changes to the documentation
- [N] My changes generate no new warnings
- [N] Any dependent changes have been merged and published in downstream modules
